### PR TITLE
Add space after commentStart string

### DIFF
--- a/settings/rust.json
+++ b/settings/rust.json
@@ -2,7 +2,7 @@
   ".source.rust": {
     "editor": {
       "autoIndentOnPaste": true,
-      "commentStart": "//",
+      "commentStart": "// ",
       "decreaseIndentPattern": "^\\s*[})\\]][;\\s]*$",
       "foldEndPattern": "^\\s*\\}",
       "increaseIndentPattern": "^.*(?:\\{[^}'\"]*|\\([^)'\"]*|\\[[^\\]'\"]*)$",

--- a/spec/rust-spec.js
+++ b/spec/rust-spec.js
@@ -528,7 +528,7 @@ describe('atom-language-rust', () => {
       // Position cursor before the 'this' word
       editor.getLastCursor().setBufferPosition([0, 9]);
       editor.toggleLineCommentsInSelection();
-      expect(buffer.getText()).toEqual('//comment this out');
+      expect(buffer.getText()).toEqual('// comment this out');
       editor.toggleLineCommentsInSelection();
       expect(buffer.getText()).toEqual(text);
     });
@@ -544,7 +544,7 @@ describe('atom-language-rust', () => {
       editor.setSelectedBufferRange([[0, 9], [2, 9]]);
       editor.toggleLineCommentsInSelection();
       expect(buffer.getText()).toEqual(
-        '//comment this out\n//comment this out\n//comment this out'
+        '// comment this out\n// comment this out\n// comment this out'
       );
       editor.toggleLineCommentsInSelection();
       expect(buffer.getText()).toEqual(text);


### PR DESCRIPTION
This results in nicer comments and is the common way to do this. 
See: https://github.com/atom/language-javascript/blob/master/settings/language-javascript.cson for example.