### PR TITLE
Fix custom color setting with dark backgrounds

### DIFF
--- a/lib/rust.js
+++ b/lib/rust.js
@@ -15,7 +15,7 @@ const STYLES_REGEX = {
   LIFETIME: /(@syntax-color-lifetime:\s+)[^;]+/,
   MACRO: /(@syntax-color-macro:\s+)[^;]+/,
   PARAMETER: /(@syntax-color-parameter:\s+)[^;]+/,
-  TOKEN: /(@syntax-color-token:\s+)[^;]+/
+  TOKEN: /(@syntax-color-token:\s+)[^;]+/g
 };
 
 class Rust {


### PR DESCRIPTION
* The RegExp only matched the first of two style rules for tokens.